### PR TITLE
maptools: build: fix parallel build on older CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ To build with ninja (need to install the ninja tool in your distro first):
 ./maptools.py build all -G Ninja
 ```
 Other generators (eclipse, codeblocks, ...) are available as well. Use
-`cmake -G` to list them.
+`cmake -G` to list them. Note that the `--make-verbose` option only works with
+the Unix Makefiles generator.
 
 ## Versioning
 <a name="ver"></a>

--- a/commands/build.py
+++ b/commands/build.py
@@ -5,6 +5,7 @@ import getpass
 import subprocess
 import collections
 import shutil
+import multiprocessing
 
 logger = logging.getLogger("build")
 build_targets=['prepare', 'clean', 'distclean', 'make']
@@ -57,8 +58,11 @@ class cmakebuilder(object):
     def make(self):
         cmd = ["cmake",
                "--build", self.build_path,
-               "--target", "install",
-               "-j" if not self.make_verbose else "-v"]
+               "--target", "install"]
+        if self.make_verbose:
+            cmd.extend(["--", "VERBOSE=1"])
+        else:
+            cmd.extend(["--", "-j", str(multiprocessing.cpu_count() + 1)])
         logger.info("building & installing {}: {}".format(self.name, " ".join(cmd)))
         subprocess.check_call(cmd, env=self.env)
 


### PR DESCRIPTION
The -j option for cmake --build was only introduce in CMake 3.12. To
support older CMake versions, replace it with a -j option passed after
the --.

Unfortunately, ninja doesn't support -j without argument. Therefore,
explicitly specify the number of jobs. One more than the number of CPUs
sounds like a good starting point.

Note that this limits the build engines to Ninja and Make, because
others don't know the -j option at all.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>